### PR TITLE
Styled fix

### DIFF
--- a/src/components/CollectionList/index.tsx
+++ b/src/components/CollectionList/index.tsx
@@ -25,8 +25,7 @@ export const CollectionList = () => {
             setIsModalVisible(true);
           }}
         >
-          <i className="fa-solid fa-plus">
-          </i> Criar Card
+          <i className="fa-solid fa-plus"></i> Criar Card
         </button>
         <button
           type="button"
@@ -39,20 +38,19 @@ export const CollectionList = () => {
             }
           }}
         >
-          <i className="fa-sharp fa-regular fa-circle-play">
-            </i> Iniciar teste
+          <i className="fa-sharp fa-regular fa-circle-play"></i> Iniciar teste
         </button>
       </StyledDiv>
       {cards.length > 0 ? (
         <CollectionCardList />
       ) : (
-        <div>
+        <div className="msg-emptyCards">
+          <p>Você ainda não possui nenhum card. 😔 </p>
           <p>
-            Não há cards Ainda <b>Crie algum card!!</b>
+            Crie um agora clicando no botão <b>+ CRIAR CARD</b> logo acima.
           </p>
         </div>
       )}
-      
     </StyledSection>
   );
 };

--- a/src/components/CollectionList/style.ts
+++ b/src/components/CollectionList/style.ts
@@ -11,6 +11,14 @@ export const StyledSection = styled.section`
   border-radius: 8px;
   background: var(--color-primary-1);
 
+  .msg-emptyCards {
+    margin: auto;
+    padding: 0 50px;
+    padding-bottom: 60px;
+    font-size: 1.5rem;
+
+  }
+
   div > p {
     color: white;
   }
@@ -18,7 +26,7 @@ export const StyledSection = styled.section`
   @media (max-width: 900px) {
     width: auto;
     max-width: 300px;
-    height: 70%;
+    height: auto;
   }
 `;
 
@@ -44,18 +52,6 @@ export const StyledDiv = styled.div`
     background: white;
   }
 
-  /* button:nth-child(2) {
-    width: 230px;
-    height: 41px;
-    background: white;
-    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-    border-radius: 7px;
-    font-weight: 700;
-    font-size: 20px;
-    border: solid 1px var(--grey-2);
-    text-transform: uppercase;
-  } */
-
   @media (max-width: 900px) {
     width: auto;
     justify-content: center;
@@ -65,11 +61,7 @@ export const StyledDiv = styled.div`
       font-size: 12px;
       padding: 0 10px;
       margin-right: 8px;
-      white-space:nowrap;
+      white-space: nowrap;
     }
-
-
   }
-
-
 `;

--- a/src/components/CollectionName/style.ts
+++ b/src/components/CollectionName/style.ts
@@ -6,34 +6,39 @@ export const StyledDiv = styled.div`
   align-self: flex-start;
   margin: 30px auto 0 auto;
   display: flex;
-  gap: 1rem;
+  gap: 5px;
 
   span {
     background: var(--grey-0);
-    width: 803px;
+    width: 822px;
+    height: 41px;
     border: 1px solid var(--grey-2);
     text-transform: uppercase;
     border-radius: 7px;
     font-weight: 700;
-    font-size: 20px;
+    font-size: 18px;
     padding: 0 20px;
     display: flex;
     align-items: center;
-
+  
   }
 
   button {
-    height: 41px;
     width: 112px;
+    height: 41px;
     background: var(--grey-0);
     border-radius: 7px;
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
     border: 1px solid var(--grey-2);
   }
 
+  button:hover {
+    background: white;
+  }
+
   @media (max-width: 900px) {
     span {
-      width: auto;
+      width: 255px;
     }
 
     button {
@@ -44,9 +49,9 @@ export const StyledDiv = styled.div`
 
 export const StyledForm = styled.form`
   display: flex;
-  gap: 5px;
   align-items: center;
   margin-top: 30px;
+  gap: 5px;
 
   input {
     width: 822px;
@@ -83,13 +88,15 @@ export const StyledForm = styled.form`
 
   @media (max-width: 900px) {
     width: auto;
+    gap: 5px;
 
     input {
-      width: auto;
+      width: 255px;
     }
 
     button {
-      width: auto;
+      width: 41px;
+      padding: 0 10px;
       font-size: 1rem;
       padding: 0 5px;
     }

--- a/src/fragments/Input/index.tsx
+++ b/src/fragments/Input/index.tsx
@@ -1,4 +1,5 @@
 import { InputHTMLAttributes, forwardRef, ForwardedRef } from "react";
+import { InputDiv } from "./style";
 
 interface IInputProps extends InputHTMLAttributes<HTMLInputElement> {
     label?: string;
@@ -6,9 +7,9 @@ interface IInputProps extends InputHTMLAttributes<HTMLInputElement> {
 
 export const Input = forwardRef(({label, ...rest}: IInputProps, ref: ForwardedRef<HTMLInputElement>) => {
     return(
-        <div>
+        <InputDiv>
             {label ? <label>{label}</label> : null}
             <input ref={ref} {...rest} />
-        </div>
+        </InputDiv>
     )
 })

--- a/src/fragments/Input/style.ts
+++ b/src/fragments/Input/style.ts
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+export const InputDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  label {
+    color: var(--grey-3);
+    font-size: 14px;
+  }
+
+  input {
+    border: none;
+    border-bottom: 2px solid red;
+    border-color: var(--grey-2);
+    background-color: var(--grey-0);
+    padding: 1px;
+  }
+`;


### PR DESCRIPTION
dashboard:
Ajustado a barra azul do rodape que ficava no modo mobile. 
Nome da coleção e botão de OK e Editar da desktop e mobile foram ajustados para ficarem do mesmo tamanho.
Ajustado a mensagem de quando não possui nenhum card.

Todos Inputs:
Incluido o style dos inputs que foi removido anteriormente.

